### PR TITLE
feat(fetch): use repository(owner,name) to support org owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+- feat(fetch): switch to `repository(owner,name)` GraphQL query in `src/fetchers/repo.js` to support organization owners (e.g., `langchain-ai/langchain`).
+- fix(pin): resolves "Could not resolve to a User" error for org logins by removing `user/organization` branching.
+- test: update `tests/fetchRepo.test.js` mocks for new response shape and unify missing/private repo error to "Repository Not found".

--- a/tests/fetchRepo.test.js
+++ b/tests/fetchRepo.test.js
@@ -30,17 +30,9 @@ const data_repo = {
   },
 };
 
-const data_user = {
+const data_repository = {
   data: {
-    user: { repository: data_repo.repository },
-    organization: null,
-  },
-};
-
-const data_org = {
-  data: {
-    user: null,
-    organization: { repository: data_repo.repository },
+    repository: data_repo.repository,
   },
 };
 
@@ -51,26 +43,11 @@ afterEach(() => {
 });
 
 describe("Test fetchRepo", () => {
-  it("should fetch correct user repo", async () => {
-    mock.onPost("https://api.github.com/graphql").reply(200, data_user);
+  it("should fetch repository by owner/name", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, data_repository);
 
     let repo = await fetchRepo("anuraghazra", "convoychat");
 
-    expect(repo).toStrictEqual({
-      ...data_repo.repository,
-      starCount: data_repo.repository.stargazers.totalCount,
-      openIssuesCount: data_repo.repository.issues.totalCount,
-      openPrsCount: data_repo.repository.pullRequests.totalCount,
-      createdAt: data_repo.repository.createdAt,
-      pushedAt: data_repo.repository.pushedAt,
-      firstCommitDate: data_repo.repository.createdAt,
-    });
-  });
-
-  it("should fetch correct org repo", async () => {
-    mock.onPost("https://api.github.com/graphql").reply(200, data_org);
-
-    let repo = await fetchRepo("anuraghazra", "convoychat");
     expect(repo).toStrictEqual({
       ...data_repo.repository,
       starCount: data_repo.repository.stargazers.totalCount,
@@ -83,45 +60,42 @@ describe("Test fetchRepo", () => {
   });
 
   it("should throw error if user is found but repo is null", async () => {
-    mock
-      .onPost("https://api.github.com/graphql")
-      .reply(200, { data: { user: { repository: null }, organization: null } });
+    mock.onPost("https://api.github.com/graphql").reply(200, {
+      data: { repository: null },
+    });
 
     await expect(fetchRepo("anuraghazra", "convoychat")).rejects.toThrow(
-      "User Repository Not found",
+      "Repository Not found",
     );
   });
 
-  it("should throw error if org is found but repo is null", async () => {
-    mock
-      .onPost("https://api.github.com/graphql")
-      .reply(200, { data: { user: null, organization: { repository: null } } });
+  it("should throw error if repo is null", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, {
+      data: { repository: null },
+    });
 
     await expect(fetchRepo("anuraghazra", "convoychat")).rejects.toThrow(
-      "Organization Repository Not found",
+      "Repository Not found",
     );
   });
 
   it("should throw error if both user & org data not found", async () => {
-    mock
-      .onPost("https://api.github.com/graphql")
-      .reply(200, { data: { user: null, organization: null } });
+    mock.onPost("https://api.github.com/graphql").reply(200, {
+      data: { repository: null },
+    });
 
     await expect(fetchRepo("anuraghazra", "convoychat")).rejects.toThrow(
-      "Not found",
+      "Repository Not found",
     );
   });
 
   it("should throw error if repository is private", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, {
-      data: {
-        user: { repository: { ...data_repo, isPrivate: true } },
-        organization: null,
-      },
+      data: { repository: { ...data_repo.repository, isPrivate: true } },
     });
 
     await expect(fetchRepo("anuraghazra", "convoychat")).rejects.toThrow(
-      "User Repository Not found",
+      "Repository Not found",
     );
   });
 });

--- a/tests/pin.test.js
+++ b/tests/pin.test.js
@@ -25,10 +25,9 @@ const data_repo = {
   },
 };
 
-const data_user = {
+const data_repository = {
   data: {
-    user: { repository: data_repo.repository },
-    organization: null,
+    repository: data_repo.repository,
   },
 };
 
@@ -50,7 +49,7 @@ describe("Test /api/pin", () => {
       setHeader: jest.fn(),
       send: jest.fn(),
     };
-    mock.onPost("https://api.github.com/graphql").reply(200, data_user);
+    mock.onPost("https://api.github.com/graphql").reply(200, data_repository);
 
     await pin(req, res);
 
@@ -79,7 +78,7 @@ describe("Test /api/pin", () => {
       setHeader: jest.fn(),
       send: jest.fn(),
     };
-    mock.onPost("https://api.github.com/graphql").reply(200, data_user);
+    mock.onPost("https://api.github.com/graphql").reply(200, data_repository);
 
     await pin(req, res);
 
@@ -95,7 +94,7 @@ describe("Test /api/pin", () => {
     );
   });
 
-  it("should render error card if user repo not found", async () => {
+  it("should render error card if repo not found", async () => {
     const req = {
       query: {
         username: "anuraghazra",
@@ -106,37 +105,14 @@ describe("Test /api/pin", () => {
       setHeader: jest.fn(),
       send: jest.fn(),
     };
-    mock
-      .onPost("https://api.github.com/graphql")
-      .reply(200, { data: { user: { repository: null }, organization: null } });
+    mock.onPost("https://api.github.com/graphql").reply(200, {
+      data: { repository: null },
+    });
 
     await pin(req, res);
 
     expect(res.setHeader).toBeCalledWith("Content-Type", "image/svg+xml");
-    expect(res.send).toBeCalledWith(renderError("User Repository Not found"));
-  });
-
-  it("should render error card if org repo not found", async () => {
-    const req = {
-      query: {
-        username: "anuraghazra",
-        repo: "convoychat",
-      },
-    };
-    const res = {
-      setHeader: jest.fn(),
-      send: jest.fn(),
-    };
-    mock
-      .onPost("https://api.github.com/graphql")
-      .reply(200, { data: { user: null, organization: { repository: null } } });
-
-    await pin(req, res);
-
-    expect(res.setHeader).toBeCalledWith("Content-Type", "image/svg+xml");
-    expect(res.send).toBeCalledWith(
-      renderError("Organization Repository Not found"),
-    );
+    expect(res.send).toBeCalledWith(renderError("Repository Not found"));
   });
 
   it("should render error card if username in blacklist", async () => {
@@ -150,7 +126,7 @@ describe("Test /api/pin", () => {
       setHeader: jest.fn(),
       send: jest.fn(),
     };
-    mock.onPost("https://api.github.com/graphql").reply(200, data_user);
+    mock.onPost("https://api.github.com/graphql").reply(200, data_repository);
 
     await pin(req, res);
 
@@ -172,7 +148,7 @@ describe("Test /api/pin", () => {
       setHeader: jest.fn(),
       send: jest.fn(),
     };
-    mock.onPost("https://api.github.com/graphql").reply(200, data_user);
+    mock.onPost("https://api.github.com/graphql").reply(200, data_repository);
 
     await pin(req, res);
 
@@ -213,7 +189,7 @@ describe("Test /api/pin", () => {
       setHeader: jest.fn(),
       send: jest.fn(),
     };
-    mock.onPost("https://api.github.com/graphql").reply(200, data_user);
+    mock.onPost("https://api.github.com/graphql").reply(200, data_repository);
 
     await pin(req, res);
 


### PR DESCRIPTION
Switch repo fetcher to top-level
GraphQL repository(owner,name) to support organization owners (e.g., langchain-ai/
langchain). Simplify error handling; unify missing/private to 'Repository Not found'.
Update tests and add changelog entry.